### PR TITLE
Allow specification of template reference in Vagrantfile

### DIFF
--- a/lib/vagrant-xenserver/action/download_xva.rb
+++ b/lib/vagrant-xenserver/action/download_xva.rb
@@ -21,75 +21,76 @@ module VagrantPlugins
 
           box_name = env[:machine].box.name.to_s
           box_version = env[:machine].box.version.to_s
+          env[:template] = env[:machine].provider_config.template
 
           @logger.info("xva_url="+xva_url.to_s)
           # Check whether we've already downloaded a VM from this URL
           # When we do, we set an other_config key 'xva_url', so we
           # can just scan through the VMs looking for it.
 
-          template = nil
-
-          Action.getlock.synchronize do
-            templates = env[:xc].VM.get_all_records_where("field \"is_a_template\"=\"true\" and field \"is_a_snapshot\"=\"false\"")
-            template = templates.detect { |vm,vmr|
-              vmr["other_config"]["box_name"] == box_name &&
-                vmr["other_config"]["box_version"] == box_version
-            }
-
-            @logger.info("template="+template.to_s)
-
-            if template.nil? && (not xva_url.nil?)
-              # No template, let's download it.
-              pool=env[:xc].pool.get_all
-              default_sr=env[:xc].pool.get_default_SR(pool[0])
-
-              env[:ui].output("Downloading XVA. This may take some time. Source URL: "+xva_url)
-              task = env[:xc].Async.VM.import(xva_url, default_sr, false, false)
-
-              begin
-                sleep(2.0)
-                task_status = env[:xc].task.get_status(task)
-                task_progress = env[:xc].task.get_progress(task) * 100.0
-                output = "Progress: #{task_progress.round(0)}%"
-                env[:ui].clear_line
-                env[:ui].detail(output, new_line: false)
-              end while task_status == "pending"
-
-              env[:ui].clear_line
-
-              if task_status != "success"
-	            # Task failed - let's find out why:
-	              error_list = env[:xc].task.get_error_info(task)
-                MyUtil::Exnhandler.handle("Async.VM.import", error_list)
-              end
-
-              task_result = env[:xc].task.get_result(task)
-
-              doc = REXML::Document.new(task_result)
-
-              @logger.debug("task_result=\"#{task_result}\"")
-              template_ref = doc.elements['value/array/data/value'].text
-
-              # Make sure it's really a template, and add the xva_url to other_config:
-              env[:xc].VM.set_is_a_template(template_ref,true)
-              env[:xc].VM.add_to_other_config(template_ref,"xva_url",xva_url)
-              env[:xc].VM.add_to_other_config(template_ref,"box_name",box_name)
-              env[:xc].VM.add_to_other_config(template_ref,"box_version",box_version)   
-
-            # Hackity hack: HVM booting guests don't need to set the bootable flag
-            # on their VBDs, but PV do. Let's set bootable=true on VBD device=0
-            # just in case.
-
-              vbds = env[:xc].VM.get_VBDs(template_ref)
-              vbds.each { |vbd|
-                if env[:xc].VBD.get_userdevice(vbd) == "0"
-                  env[:xc].VBD.set_bootable(vbd, true)
-                end
+          if env[:template].nil?
+            Action.getlock.synchronize do
+              templates = env[:xc].VM.get_all_records_where("field \"is_a_template\"=\"true\" and field \"is_a_snapshot\"=\"false\"")
+              template = templates.detect { |vm,vmr|
+                vmr["other_config"]["box_name"] == box_name &&
+                  vmr["other_config"]["box_version"] == box_version
               }
-              env[:template] = template_ref
-            else
-              (template_ref, template_rec) = template
-              env[:template] = template_ref
+
+              @logger.info("template="+template.to_s)
+
+              if template.nil? && (not xva_url.nil?)
+                # No template, let's download it.
+                pool=env[:xc].pool.get_all
+                default_sr=env[:xc].pool.get_default_SR(pool[0])
+
+                env[:ui].output("Downloading XVA. This may take some time. Source URL: "+xva_url)
+                task = env[:xc].Async.VM.import(xva_url, default_sr, false, false)
+
+                begin
+                  sleep(2.0)
+                  task_status = env[:xc].task.get_status(task)
+                  task_progress = env[:xc].task.get_progress(task) * 100.0
+                  output = "Progress: #{task_progress.round(0)}%"
+                  env[:ui].clear_line
+                  env[:ui].detail(output, new_line: false)
+                end while task_status == "pending"
+
+                env[:ui].clear_line
+
+                if task_status != "success"
+                      # Task failed - let's find out why:
+                        error_list = env[:xc].task.get_error_info(task)
+                  MyUtil::Exnhandler.handle("Async.VM.import", error_list)
+                end
+
+                task_result = env[:xc].task.get_result(task)
+
+                doc = REXML::Document.new(task_result)
+
+                @logger.debug("task_result=\"#{task_result}\"")
+                template_ref = doc.elements['value/array/data/value'].text
+
+                # Make sure it's really a template, and add the xva_url to other_config:
+                env[:xc].VM.set_is_a_template(template_ref,true)
+                env[:xc].VM.add_to_other_config(template_ref,"xva_url",xva_url)
+                env[:xc].VM.add_to_other_config(template_ref,"box_name",box_name)
+                env[:xc].VM.add_to_other_config(template_ref,"box_version",box_version)   
+
+              # Hackity hack: HVM booting guests don't need to set the bootable flag
+              # on their VBDs, but PV do. Let's set bootable=true on VBD device=0
+              # just in case.
+
+                vbds = env[:xc].VM.get_VBDs(template_ref)
+                vbds.each { |vbd|
+                  if env[:xc].VBD.get_userdevice(vbd) == "0"
+                    env[:xc].VBD.set_bootable(vbd, true)
+                  end
+                }
+                env[:template] = template_ref
+              else
+                (template_ref, template_rec) = template
+                env[:template] = template_ref
+              end
             end
           end
 

--- a/lib/vagrant-xenserver/action/upload_vhd.rb
+++ b/lib/vagrant-xenserver/action/upload_vhd.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
         end
 
         def call(env)
-          if env[:machine].provider_config.xva_url.nil?
+          if env[:machine].provider_config.xva_url.nil? and env[:machine].provider_config.template.nil?
             box_vhd_file = env[:machine].box.directory.join('box.vhd').to_s
 
             if File.exist?(box_vhd_file)

--- a/lib/vagrant-xenserver/action/upload_xva.rb
+++ b/lib/vagrant-xenserver/action/upload_xva.rb
@@ -15,80 +15,83 @@ module VagrantPlugins
         def call(env)
           box_name = env[:machine].box.name.to_s
           box_version = env[:machine].box.version.to_s
+          env[:template] = env[:machine].provider_config.template
 
-          Action.getlock.synchronize do
-            templates = env[:xc].VM.get_all_records_where("field \"is_a_template\"=\"true\"")
-            template = templates.detect { |vm,vmr|
-              vmr["other_config"]["box_name"] == box_name &&
-                 vmr["other_config"]["box_version"] == box_version
-            }
-
-            box_xva_file = env[:machine].box.directory.join('box.xva').to_s
-
-            if File.exist?(box_xva_file) && template.nil?
-              #box_image_file = env[:machine].box.directory.join('export.xva').to_s
-              hostname = env[:machine].provider_config.xs_host
-              session = env[:session]
-
-              @logger.info("box name=" + env[:machine].box.name.to_s)
-              @logger.info("box version=" + env[:machine].box.version.to_s)
-
-              # Create a task to so we can get the result of the upload
-              task = env[:xc].task.create("vagrant-xva-upload",
-                                          "Task to track progress of the XVA upload from vagrant")
-
-              url = "https://#{hostname}/import?session_id=#{env[:xc].xenapi_session}&task_id=#{task}"
-
-              uploader_options = {}
-              uploader_options[:ui] = env[:ui]
-              uploader_options[:insecure] = true
-
-              uploader = MyUtil::Uploader.new(box_xva_file, url, uploader_options)
-
-              begin
-                uploader.upload!
-              rescue
-                env[:xc].task.cancel(task)
-              end
-
-              task_status = ""
-
-              begin
-                sleep(0.2)
-                task_status = env[:xc].task.get_status(task)
-              end while task_status == "pending"
-
-              if task_status != "success"
-	            # Task failed - let's find out why:
-	              error_list = env[:xc].task.get_error_info(task)
-                MyUtil::Exnhandler.handle("VM.import", error_list)
-              end
-
-              task_result = env[:xc].task.get_result(task)
-
-              doc = REXML::Document.new(task_result)
-
-              @logger.debug("task_result=\"#{task_result}\"")
-              template_ref = doc.elements['value/array/data/value'].text
-
-              @logger.info("template_ref=" + template_ref)
-
-              # Make sure it's really a template, and add the xva_url to other_config:
-              env[:xc].VM.set_is_a_template(template_ref,true)
-              env[:xc].VM.add_to_other_config(template_ref,"box_name",box_name)
-              env[:xc].VM.add_to_other_config(template_ref,"box_version",box_version)   
-
-              # Hackity hack: HVM booting guests don't need to set the bootable flag
-              # on their VBDs, but PV do. Let's set bootable=true on VBD device=0
-              # just in case.
-
-              vbds = env[:xc].VM.get_VBDs(template_ref)
-              vbds.each { |vbd|
-                if env[:xc].VBD.get_userdevice(vbd) == "0"
-                  env[:xc].VBD.set_bootable(vbd, true)
-                end
+          if env[:template].nil?
+            Action.getlock.synchronize do
+              templates = env[:xc].VM.get_all_records_where("field \"is_a_template\"=\"true\"")
+              template = templates.detect { |vm,vmr|
+                vmr["other_config"]["box_name"] == box_name &&
+                   vmr["other_config"]["box_version"] == box_version
               }
-              env[:template] = template_ref
+
+              box_xva_file = env[:machine].box.directory.join('box.xva').to_s
+
+              if File.exist?(box_xva_file) && template.nil?
+                #box_image_file = env[:machine].box.directory.join('export.xva').to_s
+                hostname = env[:machine].provider_config.xs_host
+                session = env[:session]
+
+                @logger.info("box name=" + env[:machine].box.name.to_s)
+                @logger.info("box version=" + env[:machine].box.version.to_s)
+
+                # Create a task to so we can get the result of the upload
+                task = env[:xc].task.create("vagrant-xva-upload",
+                                            "Task to track progress of the XVA upload from vagrant")
+
+                url = "https://#{hostname}/import?session_id=#{env[:xc].xenapi_session}&task_id=#{task}"
+
+                uploader_options = {}
+                uploader_options[:ui] = env[:ui]
+                uploader_options[:insecure] = true
+
+                uploader = MyUtil::Uploader.new(box_xva_file, url, uploader_options)
+
+                begin
+                  uploader.upload!
+                rescue
+                  env[:xc].task.cancel(task)
+                end
+
+                task_status = ""
+
+                begin
+                  sleep(0.2)
+                  task_status = env[:xc].task.get_status(task)
+                end while task_status == "pending"
+
+                if task_status != "success"
+                      # Task failed - let's find out why:
+                        error_list = env[:xc].task.get_error_info(task)
+                  MyUtil::Exnhandler.handle("VM.import", error_list)
+                end
+
+                task_result = env[:xc].task.get_result(task)
+
+                doc = REXML::Document.new(task_result)
+
+                @logger.debug("task_result=\"#{task_result}\"")
+                template_ref = doc.elements['value/array/data/value'].text
+
+                @logger.info("template_ref=" + template_ref)
+
+                # Make sure it's really a template, and add the xva_url to other_config:
+                env[:xc].VM.set_is_a_template(template_ref,true)
+                env[:xc].VM.add_to_other_config(template_ref,"box_name",box_name)
+                env[:xc].VM.add_to_other_config(template_ref,"box_version",box_version)   
+
+                # Hackity hack: HVM booting guests don't need to set the bootable flag
+                # on their VBDs, but PV do. Let's set bootable=true on VBD device=0
+                # just in case.
+
+                vbds = env[:xc].VM.get_VBDs(template_ref)
+                vbds.each { |vbd|
+                  if env[:xc].VBD.get_userdevice(vbd) == "0"
+                    env[:xc].VBD.set_bootable(vbd, true)
+                  end
+                }
+                env[:template] = template_ref
+              end
             end
           end
 

--- a/lib/vagrant-xenserver/config.rb
+++ b/lib/vagrant-xenserver/config.rb
@@ -48,6 +48,11 @@ module VagrantPlugins
       # @return [Int]
       attr_accessor :memory
 
+      # template: If this is set, we'll use the template with this reference rather than downloading one or making a new one
+      #
+      # @return [String]
+      attr_accessor :template
+
       # XVA URL: If this is set, we'll assume that the XenServer should directly download an XVA from the specified URL
       #
       # @return [String]
@@ -66,6 +71,7 @@ module VagrantPlugins
         @name = UNSET_VALUE
         @pv = UNSET_VALUE
         @api_timeout = UNSET_VALUE
+        @template = UNSET_VALUE
         @memory = UNSET_VALUE
         @xva_url = UNSET_VALUE
         @use_himn = UNSET_VALUE
@@ -81,6 +87,7 @@ module VagrantPlugins
         @pv = nil if @pv == UNSET_VALUE
         @api_timeout = 60 if @api_timeout == UNSET_VALUE
         @memory = 1024 if @memory == UNSET_VALUE
+        @template = nil if @template == UNSET_VALUE
         @xva_url = nil if @xva_url == UNSET_VALUE
         @use_himn = false if @use_himn == UNSET_VALUE
       end


### PR DESCRIPTION
And skip the upload_vhd, upload_xva, download_xva steps if this template
reference is provided.

Hence this makes "vagrant up" much quicker, if you know what template you want
to use.  Typically it saves about 5 seconds multiplied by the number of nodes.

Signed-off-by: Jonathan Davies <jonathan.davies@citrix.com>