### PR TITLE
remove unused nokogiri dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.17 (18 Nov 2024)
+* Remove unused nokogiri dependency
+
 # 0.0.15 (5 Oct 2018)
 * Add xmlrpc as explicit dependency
 * Fix for md5 on OSX (wojciech@koszek.com)

--- a/lib/vagrant-xenserver/action/prepare_nfs_settings.rb
+++ b/lib/vagrant-xenserver/action/prepare_nfs_settings.rb
@@ -1,4 +1,3 @@
-require 'nokogiri'
 require 'socket'
 require 'rbconfig'
 

--- a/lib/vagrant-xenserver/version.rb
+++ b/lib/vagrant-xenserver/version.rb
@@ -1,6 +1,6 @@
 module VagrantPlugins
   module XenServer
-    VERSION = "0.0.16"
+    VERSION = "0.0.17"
   end
 end
 

--- a/vagrant-xenserver.gemspec
+++ b/vagrant-xenserver.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.description   = "Enables Vagrant to manage XenServers."
 
   s.add_development_dependency "rake"
-  s.add_runtime_dependency "nokogiri", "~> 1.6.3"
   s.add_runtime_dependency "json"
   s.add_runtime_dependency "xenapi"
   s.add_runtime_dependency "xmlrpc"


### PR DESCRIPTION
In the latest release of Vagrant the plugin will not load. See https://github.com/xapi-project/vagrant-xenserver/issues/62
It seems like `nokogiri` is giving issues. I don't see any usage of the library in the code except for the require in `action/prepare_nfs_settings.rb]`

Also bumped the version.